### PR TITLE
Dashboard timeframe parametrized from GET parameters.

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -25,7 +25,9 @@ a jira plug-in that costs money and could change the standard jira time tracking
 this to work with the default jira time tracking solution (work logs)
 
 The current reporting options in Jira Cloud are somewhat limiting and unless you purchase an add-on the
-time spent by developers is difficult to report on. This utility is looking to change that
+time spent by developers is difficult to report on. This utility is looking to change that.
+
+If you follow [https://en.wikipedia.org/wiki/Pomodoro_Technique](the pomodoro technique) and wish to log your work many times a day to various issues, it is imperative to be able to tell how much work you logged so far. With stock Jira, it is practically impossible to deduct.
 
 ## Configuration
 
@@ -123,7 +125,17 @@ Given that we can pull all work log entries and from those entries get the issue
 
 ## dashboard Thoughts (WIP)
 
+### Get parameters
+
+./issues.html and ./worklogs.html can be parametrized to preload a desired timeframe, eg.
+
+- ./issues.html?start=lastweek
+- ./issues.html?start=2021-12-08&end=2021-12-24
+- ./issues.html  # loads the current week
+
 ### Issues
+
+Accessed by http://localhost:8180/issues.html
 
 - Historical page?
   - The days to complete by type line chart below could fit here
@@ -142,6 +154,8 @@ Days to complete by type
  - line chart going back 6 weeks. Each week point
 
 ### Worklogs
+
+Accessed by http://localhost:8180/worklogs.html
 
 Who hasn't logged any hours for today
 

--- a/web/helpers.js
+++ b/web/helpers.js
@@ -1,0 +1,30 @@
+function parseGetParams() {
+    return new URLSearchParams(window.location.search);
+}
+
+function parseStartEndParams(q) {
+    let start;
+    let end;
+
+    if (q.get("start") === "lastweek") {
+        start = moment().subtract(1, "weeks").startOf('isoWeek');
+        if (!q.get("end")) {
+            end = moment().subtract(1, "weeks").endOf('isoWeek');
+        }
+    }
+    if (!start && q.get("start")) {
+        start = moment(q.get("start"), "YYYY-MM-DD");
+        if (!q.get("end")) {
+            end = moment(start).add(1, "weeks");
+        }
+    }
+    if (!end && q.get("end")) {
+        end = moment(q.get("end"), "YYYY-MM-DD");
+        if (!q.get("start")) {
+            start = moment(end).subtract(1, "weeks");
+        }
+    }
+    if (!start) { start = moment().subtract(0, 'weeks').startOf('isoWeek'); }
+    if (!end) { end = moment().subtract(0, 'weeks').endOf('isoWeek'); }
+    return [start, end];
+}

--- a/web/issues.html
+++ b/web/issues.html
@@ -33,13 +33,15 @@
     <script type="text/javascript" src="https://cdn.jsdelivr.net/momentjs/latest/moment.min.js"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js"></script>
 
+    <!-- Local helpers -->
+    <script type="text/javascript" src="./helpers.js"></script>
+
     <script>
         $(function () {
             //var selected = getQueryString("weeksBack", window.location.href);
             //$('#timespan').val(selected);
 
-            var start = moment().subtract(1, 'weeks').startOf('isoWeek');
-            var end =moment().subtract(1, 'weeks').endOf('isoWeek');
+            let [start, end] = parseStartEndParams(parseGetParams());
 
             function cb(start, end) {
                 $('#reportrange span').html(start.format('YYYY-MM-DD') + ' - ' + end.format('YYYY-MM-DD'));

--- a/web/worklogs.html
+++ b/web/worklogs.html
@@ -30,11 +30,13 @@
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js"></script>
 
 
+    <!-- Local helpers -->
+    <script type="text/javascript" src="./helpers.js"></script>
+
     <script>
         $(function () {
 
-            var start = moment().subtract(1, 'weeks').startOf('isoWeek');
-            var end =moment().subtract(1, 'weeks').endOf('isoWeek');
+            let [start, end] = parseStartEndParams(parseGetParams());
 
             function cb(start, end) {
                 $('#reportrange span').html(start.format('YYYY-MM-DD') + ' - ' + end.format('YYYY-MM-DD'));


### PR DESCRIPTION
./issues.html and ./worklogs.html can be parametrized to preload a desired timeframe, eg.

- ./issues.html?start=lastweek
- ./issues.html?start=2021-12-08&end=2021-12-24
- ./issues.html  # loads the current week